### PR TITLE
include/grub/tis.h: do not export grub_tis funcs

### DIFF
--- a/grub-core/Makefile.core.def
+++ b/grub-core/Makefile.core.def
@@ -1798,6 +1798,7 @@ module = {
   x86 = loader/i386/slaunch.c;
   x86 = loader/i386/slaunch_txt.c;
   x86 = loader/i386/slaunch_skinit.c;
+  x86 = kern/tis.c;
   enable = x86;
 };
 

--- a/grub-core/loader/i386/linux.c
+++ b/grub-core/loader/i386/linux.c
@@ -578,15 +578,6 @@ grub_linux_boot (void)
   grub_memcpy (ctx.params->cmd_line_ptr, linux_cmdline,
 	       maximal_cmdline_size);
 
-  grub_dprintf ("linux", "cmd_line_ptr = %p\n",
-                ctx.params->cmd_line_ptr);
-  grub_dprintf ("linux", "old cmdline = %s\n",
-                linux_cmdline);
-  grub_dprintf ("linux", "new cmdline = %s\n",
-                (char *) ctx.params + cl_offset);
-  grub_dprintf ("linux", "new cmdline addr = %p\n",
-                (char *) ctx.params + cl_offset);
-
   grub_dprintf ("linux", "code32_start = %x\n",
 		(unsigned) ctx.params->code32_start);
 

--- a/grub-core/loader/i386/linux.c
+++ b/grub-core/loader/i386/linux.c
@@ -575,6 +575,18 @@ grub_linux_boot (void)
   grub_memcpy ((char *) ctx.params + cl_offset, linux_cmdline,
 	       maximal_cmdline_size);
 
+  grub_memcpy (ctx.params->cmd_line_ptr, linux_cmdline,
+	       maximal_cmdline_size);
+
+  grub_dprintf ("linux", "cmd_line_ptr = %p\n",
+                ctx.params->cmd_line_ptr);
+  grub_dprintf ("linux", "old cmdline = %s\n",
+                linux_cmdline);
+  grub_dprintf ("linux", "new cmdline = %s\n",
+                (char *) ctx.params + cl_offset);
+  grub_dprintf ("linux", "new cmdline addr = %p\n",
+                (char *) ctx.params + cl_offset);
+
   grub_dprintf ("linux", "code32_start = %x\n",
 		(unsigned) ctx.params->code32_start);
 

--- a/grub-core/loader/i386/linux.c
+++ b/grub-core/loader/i386/linux.c
@@ -81,7 +81,7 @@ static grub_efi_uintn_t efi_mmap_size;
 #else
 static const grub_size_t efi_mmap_size = 0;
 #endif
-static grub_err_t (*grub_slaunch_func) (struct grub_slaunch_params*) = NULL;
+static grub_err_t (*grub_slaunch_func) (struct grub_slaunch_params*, struct grub_relocator*) = NULL;
 static struct grub_slaunch_params slparams;
 
 /* FIXME */
@@ -100,7 +100,7 @@ static struct idt_descriptor idt_desc =
 #endif
 
 void
-grub_linux_slaunch_set (grub_err_t (*sfunc) (struct grub_slaunch_params*))
+grub_linux_slaunch_set (grub_err_t (*sfunc) (struct grub_slaunch_params*, struct grub_relocator*))
 {
   grub_slaunch_func = sfunc;
 }
@@ -575,8 +575,8 @@ grub_linux_boot (void)
   grub_memcpy ((char *) ctx.params + cl_offset, linux_cmdline,
 	       maximal_cmdline_size);
 
-  grub_memcpy (ctx.params->cmd_line_ptr, linux_cmdline,
-	       maximal_cmdline_size);
+  //~ grub_memcpy (ctx.params->cmd_line_ptr, linux_cmdline,
+	       //~ maximal_cmdline_size);
 
   grub_dprintf ("linux", "code32_start = %x\n",
 		(unsigned) ctx.params->code32_start);
@@ -634,7 +634,7 @@ grub_linux_boot (void)
       slparams.params = ctx.params;
       slparams.real_mode_target = ctx.real_mode_target;
       slparams.prot_mode_target = prot_mode_target;
-      return grub_slaunch_func (&slparams);
+      return grub_slaunch_func (&slparams, relocator);
     }
 
   /* FIXME.  */

--- a/grub-core/loader/i386/slaunch.c
+++ b/grub-core/loader/i386/slaunch.c
@@ -179,9 +179,9 @@ grub_cmd_slaunch_module (grub_command_t cmd __attribute__ ((unused)),
 
   grub_printf("%s:%d: allocate memory\r\n", __FUNCTION__, __LINE__);
   err = grub_relocator_alloc_chunk_align (relocator, &ch,
-					  0x4000000, /* hardcode for debug purposes */
+					  0x2000000, /* hardcode for debug purposes, must be < 0x3000000 because of DEV */
 					  (0xffffffff - size) + 1,
-					  size, 0x1000,
+					  size, 0x10000,
 					  GRUB_RELOCATOR_PREFERENCE_NONE, 1);
   if (err)
     {

--- a/grub-core/loader/i386/slaunch_skinit.c
+++ b/grub-core/loader/i386/slaunch_skinit.c
@@ -26,10 +26,24 @@
 #include <grub/slaunch.h>
 #include <grub/i386/relocator.h>
 
+static void skinit(void) {
+  __asm__("push %eax\n\
+  mov $0x3f8, %dx\n\
+  mov $'X', %ax\n\
+  outb %al, %dx\n\
+  pop %eax\n\
+  skinit\n\
+  mov $0x3f8, %dx\n\
+  mov $'x', %ax\n\
+  outb %al, %dx\n\
+  .byte 0xeb, 0xfe");
+}
+
 grub_err_t
-grub_slaunch_boot_skinit (struct grub_slaunch_params *slparams)
+grub_slaunch_boot_skinit (struct grub_slaunch_params *slparams, struct grub_relocator *relocator)
 {
   grub_uint32_t *slb = (grub_uint32_t *)0x2000000;
+  struct grub_relocator32_state state;
 
   grub_printf("%s:%d: real_mode_target: 0x%x\r\n", __FUNCTION__, __LINE__, slparams->real_mode_target);
   grub_printf("%s:%d: prot_mode_target: 0x%x\r\n", __FUNCTION__, __LINE__, slparams->prot_mode_target);
@@ -37,19 +51,16 @@ grub_slaunch_boot_skinit (struct grub_slaunch_params *slparams)
 
   /* FIXME: some variant of this is done by grub_relocator32_boot(),
    * check if some additional magic code relocation stuff is done there */
-  grub_memmove((void*)0x1000000, (void*)0x100000, 6*1024*1024);
+  //grub_memmove((void*)0x1000000, (void*)0x100000, 6*1024*1024);
 
   slb[GRUB_SL_ZEROPAGE_OFFSET/4] = (grub_uint32_t)slparams->params;
   grub_dprintf("linux", "Invoke SKINIT\r\n");
 
   if (grub_slaunch_get_modules()) {
-    __asm__ ("skinit;"
-	     : /* no output */
-	     : "a" ( slb )
-	     : /* no clobbered reg */
-	);
-
-    grub_dprintf("linux", "SKINIT exit\r\n");
+    state.eax = slb;
+    state.esp = slparams->real_mode_target;
+    state.eip = skinit;
+    return grub_relocator32_boot (relocator, state, 0);
   } else {
     grub_dprintf("linux", "Secure Loader module not loaded, run slaunch_module\r\n");
   }

--- a/grub-core/loader/i386/slaunch_skinit.c
+++ b/grub-core/loader/i386/slaunch_skinit.c
@@ -25,6 +25,7 @@
 #include <grub/dl.h>
 #include <grub/slaunch.h>
 #include <grub/i386/relocator.h>
+#include <grub/tis.h>
 
 static void skinit(void) {
   __asm__("push %eax\n\
@@ -57,6 +58,9 @@ grub_slaunch_boot_skinit (struct grub_slaunch_params *slparams, struct grub_relo
   grub_dprintf("linux", "Invoke SKINIT\r\n");
 
   if (grub_slaunch_get_modules()) {
+    grub_tis_init();
+    grub_tis_request_locality(0xff);
+
     state.eax = slb;
     state.esp = slparams->real_mode_target;
     state.eip = skinit;

--- a/grub-core/loader/i386/slaunch_skinit.c
+++ b/grub-core/loader/i386/slaunch_skinit.c
@@ -26,66 +26,20 @@
 #include <grub/slaunch.h>
 #include <grub/i386/relocator.h>
 
-static void *
-allocate_zeropage(void)
-{
-  grub_err_t err;
-  void *addr = NULL;
-
-  struct grub_relocator *relocator = grub_relocator_new ();
-  if (!relocator)
-  {
-    err = grub_errno;
-    goto fail;
-  }
-
-  grub_relocator_chunk_t ch;
-  {
-    err = grub_relocator_alloc_chunk_align (relocator, &ch,
-					    0x1000, 0x90000,
-					    0x1000, 0x1000,
-					    GRUB_RELOCATOR_PREFERENCE_LOW,
-					    0);
-    if (err)
-      goto fail;
-  }
-
-  addr = (void *)get_virtual_current_address(ch);
-
-fail:
-  grub_relocator_unload(relocator);
-  return addr;
-}
-
 grub_err_t
 grub_slaunch_boot_skinit (struct grub_slaunch_params *slparams)
 {
-  char *new_zeropage = NULL;
-  grub_uint8_t *slb = (grub_uint8_t *)0x2000000;
+  grub_uint32_t *slb = (grub_uint32_t *)0x2000000;
 
   grub_printf("%s:%d: real_mode_target: 0x%x\r\n", __FUNCTION__, __LINE__, slparams->real_mode_target);
   grub_printf("%s:%d: prot_mode_target: 0x%x\r\n", __FUNCTION__, __LINE__, slparams->prot_mode_target);
   grub_printf("%s:%d: params: %p\r\n", __FUNCTION__, __LINE__, slparams->params);
 
-  new_zeropage = allocate_zeropage();
-  if (new_zeropage == NULL) {
-    grub_dprintf("linux", "Couldn't allocate low memory for zeropage\r\n");
-    return GRUB_ERR_OUT_OF_MEMORY;
-  }
-  new_zeropage -= 0x1000;	/* FIXME: memmove throws exception with allocated address, why? */
-  grub_printf("%s:%d: new_zeropage: %p\r\n", __FUNCTION__, __LINE__, new_zeropage);
-
   /* FIXME: some variant of this is done by grub_relocator32_boot(),
    * check if some additional magic code relocation stuff is done there */
   grub_memmove((void*)0x1000000, (void*)0x100000, 6*1024*1024);
 
-  grub_printf("%s:%d: memmove(%p, %p, 0x%lx) \r\n", __FUNCTION__, __LINE__, new_zeropage,
-		slparams->params, sizeof(*slparams->params));
-  grub_memmove(new_zeropage, slparams->params, sizeof(*slparams->params));
-  grub_printf("%s:%d:         DONE\r\n", __FUNCTION__, __LINE__);
-
-  /* FIXME: rewrite into something human-readable */
-  *((grub_uint32_t *)&slb[0x18]) = (grub_uint32_t)new_zeropage;
+  slb[GRUB_SL_ZEROPAGE_OFFSET/4] = (grub_uint32_t)slparams->params;
   grub_dprintf("linux", "Invoke SKINIT\r\n");
 
   if (grub_slaunch_get_modules()) {

--- a/grub-core/loader/i386/slaunch_skinit.c
+++ b/grub-core/loader/i386/slaunch_skinit.c
@@ -24,20 +24,74 @@
 #include <grub/types.h>
 #include <grub/dl.h>
 #include <grub/slaunch.h>
+#include <grub/i386/relocator.h>
+
+static void *
+allocate_zeropage(void)
+{
+  grub_err_t err;
+  void *addr = NULL;
+
+  struct grub_relocator *relocator = grub_relocator_new ();
+  if (!relocator)
+  {
+    err = grub_errno;
+    goto fail;
+  }
+
+  grub_relocator_chunk_t ch;
+  {
+    err = grub_relocator_alloc_chunk_align (relocator, &ch,
+					    0x1000, 0x90000,
+					    0x1000, 0x1000,
+					    GRUB_RELOCATOR_PREFERENCE_LOW,
+					    0);
+    if (err)
+      goto fail;
+  }
+
+  addr = (void *)get_virtual_current_address(ch);
+
+fail:
+  grub_relocator_unload(relocator);
+  return addr;
+}
 
 grub_err_t
 grub_slaunch_boot_skinit (struct grub_slaunch_params *slparams)
 {
-  slparams = slparams;
+  char *new_zeropage = NULL;
+  grub_uint8_t *slb = (grub_uint8_t *)0x2000000;
 
   grub_printf("%s:%d: real_mode_target: 0x%x\r\n", __FUNCTION__, __LINE__, slparams->real_mode_target);
-  grub_printf("%s:%d: prot_mode_target: 0x%lx\r\n", __FUNCTION__, __LINE__, slparams->prot_mode_target);
+  grub_printf("%s:%d: prot_mode_target: 0x%x\r\n", __FUNCTION__, __LINE__, slparams->prot_mode_target);
+  grub_printf("%s:%d: params: %p\r\n", __FUNCTION__, __LINE__, slparams->params);
+
+  new_zeropage = allocate_zeropage();
+  if (new_zeropage == NULL) {
+    grub_dprintf("linux", "Couldn't allocate low memory for zeropage\r\n");
+    return GRUB_ERR_OUT_OF_MEMORY;
+  }
+  new_zeropage -= 0x1000;	/* FIXME: memmove throws exception with allocated address, why? */
+  grub_printf("%s:%d: new_zeropage: %p\r\n", __FUNCTION__, __LINE__, new_zeropage);
+
+  /* FIXME: some variant of this is done by grub_relocator32_boot(),
+   * check if some additional magic code relocation stuff is done there */
+  grub_memmove((void*)0x1000000, (void*)0x100000, 6*1024*1024);
+
+  grub_printf("%s:%d: memmove(%p, %p, 0x%lx) \r\n", __FUNCTION__, __LINE__, new_zeropage,
+		slparams->params, sizeof(*slparams->params));
+  grub_memmove(new_zeropage, slparams->params, sizeof(*slparams->params));
+  grub_printf("%s:%d:         DONE\r\n", __FUNCTION__, __LINE__);
+
+  /* FIXME: rewrite into something human-readable */
+  *((grub_uint32_t *)&slb[0x18]) = (grub_uint32_t)new_zeropage;
   grub_dprintf("linux", "Invoke SKINIT\r\n");
 
   if (grub_slaunch_get_modules()) {
     __asm__ ("skinit;"
 	     : /* no output */
-	     : "a" ( 0x4000000 )
+	     : "a" ( slb )
 	     : /* no clobbered reg */
 	);
 

--- a/grub-core/loader/i386/slaunch_txt.c
+++ b/grub-core/loader/i386/slaunch_txt.c
@@ -25,11 +25,13 @@
 #include <grub/dl.h>
 #include <grub/cpu/txt.h>
 #include <grub/slaunch.h>
+#include <grub/i386/relocator.h>
 
 grub_err_t
-grub_slaunch_boot_txt (struct grub_slaunch_params *slparams)
+grub_slaunch_boot_txt (struct grub_slaunch_params *slparams, struct grub_relocator *relocator)
 {
   slparams = slparams;
+  relocator = relocator;
 
   return GRUB_ERR_NONE;
 }

--- a/include/grub/slaunch.h
+++ b/include/grub/slaunch.h
@@ -25,6 +25,7 @@
 #include <grub/i386/linux.h>
 
 #define GRUB_SL_BOOTPARAMS_OFFSET	0x12c
+#define GRUB_SL_ZEROPAGE_OFFSET		0x18
 
 struct grub_slaunch_info
 {

--- a/include/grub/slaunch.h
+++ b/include/grub/slaunch.h
@@ -23,6 +23,7 @@
 
 #include <grub/types.h>
 #include <grub/i386/linux.h>
+#include <grub/i386/relocator.h>
 
 #define GRUB_SL_BOOTPARAMS_OFFSET	0x12c
 #define GRUB_SL_ZEROPAGE_OFFSET		0x18
@@ -53,9 +54,9 @@ struct grub_slaunch_module
 
 struct grub_slaunch_module *grub_slaunch_get_modules (void);
 
-grub_err_t grub_slaunch_boot_txt (struct grub_slaunch_params *slparams);
-grub_err_t grub_slaunch_boot_skinit (struct grub_slaunch_params *slparams);
+grub_err_t grub_slaunch_boot_txt (struct grub_slaunch_params *slparams, struct grub_relocator *relocator);
+grub_err_t grub_slaunch_boot_skinit (struct grub_slaunch_params *slparams, struct grub_relocator *relocator);
 
-void grub_linux_slaunch_set (grub_err_t (*sfunc) (struct grub_slaunch_params*));
+void grub_linux_slaunch_set (grub_err_t (*sfunc) (struct grub_slaunch_params*, struct grub_relocator*));
 
 #endif

--- a/include/grub/tis.h
+++ b/include/grub/tis.h
@@ -145,10 +145,10 @@ struct grub_tpm_resp_buf
 };
 
 /* TPM Interface Specification functions */
-grub_uint8_t EXPORT_FUNC(grub_tis_request_locality) (grub_uint8_t l);
-grub_uint8_t EXPORT_FUNC(grub_tis_init) (void);
-grub_size_t EXPORT_FUNC(grub_tis_send) (struct grub_tpm_cmd_buf *buf);
-grub_size_t EXPORT_FUNC(grub_tis_recv) (struct grub_tpm_resp_buf *buf);
+grub_uint8_t grub_tis_request_locality (grub_uint8_t l);
+grub_uint8_t grub_tis_init (void);
+grub_size_t grub_tis_send (struct grub_tpm_cmd_buf *buf);
+grub_size_t grub_tis_recv (struct grub_tpm_resp_buf *buf);
 
 /* TPM Commands */
 grub_uint8_t EXPORT_FUNC(grub_tpm_pcr_extend) (struct grub_tpm_digest *d);


### PR DESCRIPTION
Syms were exposed both by kernel and module
The result was following error when building for PC platform:

grub_tis_init in slaunch is duplicated in kernel
grub_tis_recv in slaunch is duplicated in kernel
grub_tis_request_locality in slaunch is duplicated in kernel
grub_tis_send in slaunch is duplicated in kernel
Makefile:49185: recipe for target 'moddep.lst' failed

Signed-off-by: Maciej Pijanowski <maciej.pijanowski@3mdeb.com>