### PR TITLE
slaunch: implement relocator for SKINIT

### DIFF
--- a/grub-core/Makefile.core.def
+++ b/grub-core/Makefile.core.def
@@ -1644,6 +1644,8 @@ module = {
   x86_64_xen = lib/x86_64/xen/relocator.S;
   xen = lib/i386/relocator_common_c.c;
   x86_64_efi = lib/x86_64/efi/relocator.c;
+  x86 = lib/i386/relocator_slaunch_asm.S;
+  x86 = lib/i386/relocator_slaunch.c;
 
   extra_dist = lib/i386/relocator_common.S;
   extra_dist = kern/powerpc/cache_flush.S;

--- a/grub-core/lib/i386/relocator_slaunch.c
+++ b/grub-core/lib/i386/relocator_slaunch.c
@@ -1,0 +1,71 @@
+/*
+ *  GRUB  --  GRand Unified Bootloader
+ *  Copyright (C) 2009  Free Software Foundation, Inc.
+ *  Copyright (C) 2019 3mdeb Embedded Systems Consulting
+ *
+ *  GRUB is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  GRUB is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with GRUB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <grub/mm.h>
+#include <grub/misc.h>
+
+#include <grub/types.h>
+#include <grub/err.h>
+#include <grub/term.h>
+
+#include <grub/i386/relocator.h>
+#include <grub/relocator_private.h>
+#include <grub/i386/relocator_private.h>
+#include <grub/i386/pc/int.h>
+
+extern grub_uint8_t grub_relocator_skinit_start;
+extern grub_uint8_t grub_relocator_skinit_end;
+extern grub_uint32_t *grub_relocator_skinit_slb;
+
+
+#define RELOCATOR_SIZEOF(x)	(&grub_relocator##x##_end - &grub_relocator##x##_start)
+
+grub_err_t
+grub_relocator_skinit_boot (struct grub_relocator *rel,
+		       grub_uint32_t *slb,
+		       int avoid_efi_bootservices)
+{
+  grub_err_t err;
+  void *relst;
+  grub_relocator_chunk_t ch;
+
+  err = grub_relocator_alloc_chunk_align (rel, &ch, 0x1000,
+					  0x100000000 - RELOCATOR_SIZEOF (_skinit),
+					  RELOCATOR_SIZEOF (_skinit), 16,
+					  GRUB_RELOCATOR_PREFERENCE_LOW,
+					  avoid_efi_bootservices);
+  if (err)
+    return err;
+
+  grub_relocator_skinit_slb = slb;
+
+  grub_memmove (get_virtual_current_address (ch), &grub_relocator_skinit_start,
+		RELOCATOR_SIZEOF (_skinit));
+
+  err = grub_relocator_prepare_relocs (rel, get_physical_target_address (ch),
+				       &relst, NULL);
+  if (err)
+    return err;
+
+  asm volatile ("cli");
+  ((void (*) (void)) relst) ();
+
+  /* Not reached.  */
+  return GRUB_ERR_NONE;
+}

--- a/grub-core/lib/i386/relocator_slaunch.c
+++ b/grub-core/lib/i386/relocator_slaunch.c
@@ -31,14 +31,14 @@
 
 extern grub_uint8_t grub_relocator_skinit_start;
 extern grub_uint8_t grub_relocator_skinit_end;
-extern grub_uint32_t *grub_relocator_skinit_slb;
+extern grub_addr_t grub_relocator_skinit_slb;
 
 
 #define RELOCATOR_SIZEOF(x)	(&grub_relocator##x##_end - &grub_relocator##x##_start)
 
 grub_err_t
 grub_relocator_skinit_boot (struct grub_relocator *rel,
-		       grub_uint32_t *slb,
+		       grub_addr_t slb,
 		       int avoid_efi_bootservices)
 {
   grub_err_t err;

--- a/grub-core/lib/i386/relocator_slaunch_asm.S
+++ b/grub-core/lib/i386/relocator_slaunch_asm.S
@@ -1,0 +1,37 @@
+/*
+ *  GRUB  --  GRand Unified Bootloader
+ *  Copyright (C) 2019 3mdeb Embedded Systems Consulting
+ *
+ *  GRUB is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  GRUB is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with GRUB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * skinit resets the CPU state. Assuming we are already in protected mode
+ * (doesn't matter if it is legacy, compatibility or long mode) with CPL=0,
+ * there is no additional setup to be done.
+ */
+
+#include <grub/symbol.h>
+
+	.p2align	4	/* force 16-byte alignment */
+
+VARIABLE(grub_relocator_skinit_start)
+
+	/* mov imm32, %eax */
+	.byte	0xb8
+VARIABLE(grub_relocator_skinit_slb)
+	.long	0
+
+	skinit
+VARIABLE(grub_relocator_skinit_end)

--- a/grub-core/loader/i386/slaunch_skinit.c
+++ b/grub-core/loader/i386/slaunch_skinit.c
@@ -43,7 +43,7 @@ grub_slaunch_boot_skinit (struct grub_slaunch_params *slparams)
     grub_printf("%s:%d: params: %p\r\n", __FUNCTION__, __LINE__, slparams->params);
 
     // TODO: save kernel size for measuring in LZ
-    boot_data[GRUB_SL_ZEROPAGE_OFFSET/4] = (grub_uint32_t)slparams->params;
+    boot_data[GRUB_SL_ZEROPAGE_OFFSET/4] = (grub_uint32_t)slparams->real_mode_target;
     *apic = 0x000c0500;               // INIT, all excluding self
 
     grub_tis_init();

--- a/grub-core/loader/i386/slaunch_skinit.c
+++ b/grub-core/loader/i386/slaunch_skinit.c
@@ -25,27 +25,32 @@
 #include <grub/dl.h>
 #include <grub/slaunch.h>
 
+static inline grub_uint32_t *get_bootloader_data_addr (struct grub_slaunch_module *mod)
+{
+  grub_uint16_t *ptr = (grub_uint16_t *)mod->addr;
+  return (grub_uint32_t *)(mod->addr + ptr[1]);
+}
+
 grub_err_t
 grub_slaunch_boot_skinit (struct grub_slaunch_params *slparams)
 {
   if (grub_slaunch_get_modules()) {
-    grub_uint32_t *slb = (grub_uint32_t *)grub_slaunch_get_modules()->target;
+    grub_uint32_t *boot_data = get_bootloader_data_addr(grub_slaunch_get_modules());
     grub_uint32_t *apic = (grub_uint32_t *)0xfee00300ULL;
 
     grub_printf("%s:%d: real_mode_target: 0x%x\r\n", __FUNCTION__, __LINE__, slparams->real_mode_target);
     grub_printf("%s:%d: prot_mode_target: 0x%x\r\n", __FUNCTION__, __LINE__, slparams->prot_mode_target);
     grub_printf("%s:%d: params: %p\r\n", __FUNCTION__, __LINE__, slparams->params);
 
-    // TODO: move outside of measured part of SLB
-    // TODO2: save kernel size for measuring in LZ
-    slb[GRUB_SL_ZEROPAGE_OFFSET/4] = (grub_uint32_t)slparams->params;
+    // TODO: save kernel size for measuring in LZ
+    boot_data[GRUB_SL_ZEROPAGE_OFFSET/4] = (grub_uint32_t)slparams->params;
     *apic = 0x000c0500;               // INIT, all excluding self
 
     grub_tis_init();
     grub_tis_request_locality(0xff);  // relinquish all localities
 
     grub_dprintf("linux", "Invoke SKINIT\r\n");
-    return grub_relocator_skinit_boot (slparams->relocator, slb, 0);
+    return grub_relocator_skinit_boot (slparams->relocator, grub_slaunch_get_modules()->target, 0);
   } else {
     grub_dprintf("linux", "Secure Loader module not loaded, run slaunch_module\r\n");
   }

--- a/include/grub/i386/relocator.h
+++ b/include/grub/i386/relocator.h
@@ -90,6 +90,10 @@ grub_err_t grub_relocator64_boot (struct grub_relocator *rel,
 				  struct grub_relocator64_state state,
 				  grub_addr_t min_addr, grub_addr_t max_addr);
 
+grub_err_t grub_relocator_skinit_boot (struct grub_relocator *rel,
+				  grub_uint32_t *slb,
+				  int avoid_efi_bootservices);
+
 #ifdef GRUB_MACHINE_EFI
 #ifdef __x86_64__
 grub_err_t grub_relocator64_efi_boot (struct grub_relocator *rel,

--- a/include/grub/i386/relocator.h
+++ b/include/grub/i386/relocator.h
@@ -91,7 +91,7 @@ grub_err_t grub_relocator64_boot (struct grub_relocator *rel,
 				  grub_addr_t min_addr, grub_addr_t max_addr);
 
 grub_err_t grub_relocator_skinit_boot (struct grub_relocator *rel,
-				  grub_uint32_t *slb,
+				  grub_addr_t slb,
 				  int avoid_efi_bootservices);
 
 #ifdef GRUB_MACHINE_EFI

--- a/include/grub/slaunch.h
+++ b/include/grub/slaunch.h
@@ -27,7 +27,7 @@
 #include <grub/tis.h>
 
 #define GRUB_SL_BOOTPARAMS_OFFSET	0x12c
-#define GRUB_SL_ZEROPAGE_OFFSET		0x18
+#define GRUB_SL_ZEROPAGE_OFFSET		0x14
 
 struct grub_slaunch_info
 {


### PR DESCRIPTION
SKINIT instruction takes only one argument in EAX register - a pointer
to the SLB (Secure Launch Block). No other registers are preserved by
SKINIT, so don't bother setting the rest of CPU state.

Signed-off-by: Krystian Hebel <krystian.hebel@3mdeb.com>