### PR TITLE
include/grub/tis.h: do not export grub_tis funcs

### DIFF
--- a/include/grub/tis.h
+++ b/include/grub/tis.h
@@ -145,10 +145,10 @@ struct grub_tpm_resp_buf
 };
 
 /* TPM Interface Specification functions */
-grub_uint8_t EXPORT_FUNC(grub_tis_request_locality) (grub_uint8_t l);
-grub_uint8_t EXPORT_FUNC(grub_tis_init) (void);
-grub_size_t EXPORT_FUNC(grub_tis_send) (struct grub_tpm_cmd_buf *buf);
-grub_size_t EXPORT_FUNC(grub_tis_recv) (struct grub_tpm_resp_buf *buf);
+grub_uint8_t grub_tis_request_locality (grub_uint8_t l);
+grub_uint8_t grub_tis_init (void);
+grub_size_t grub_tis_send (struct grub_tpm_cmd_buf *buf);
+grub_size_t grub_tis_recv (struct grub_tpm_resp_buf *buf);
 
 /* TPM Commands */
 grub_uint8_t EXPORT_FUNC(grub_tpm_pcr_extend) (struct grub_tpm_digest *d);


### PR DESCRIPTION
Syms were exposed both by kernel and module
The result was following error when building for PC platform:

grub_tis_init in slaunch is duplicated in kernel
grub_tis_recv in slaunch is duplicated in kernel
grub_tis_request_locality in slaunch is duplicated in kernel
grub_tis_send in slaunch is duplicated in kernel
Makefile:49185: recipe for target 'moddep.lst' failed

Signed-off-by: Maciej Pijanowski <maciej.pijanowski@3mdeb.com>